### PR TITLE
Fix skill name rendering containing underscores

### DIFF
--- a/client/src/events/production.rs
+++ b/client/src/events/production.rs
@@ -1,4 +1,5 @@
 use crate::App;
+use ragnarok_game::data_table::skill_name_table::format_skill_display_name;
 use models::enums::skill_enums::SkillEnum;
 use ragnarok_game::entity::EntityState;
 use ragnarok_game::event::{RefineItemRow, VendorItem};
@@ -146,13 +147,10 @@ impl App {
                 let skill = self.game.character.skills.get_skill(id as u16);
                 let (name, icon) = match skill {
                     Some(s) => {
-                        let display = self
-                            .game
-                            .data_table
-                            .skill_name
-                            .as_ref()
-                            .map(|t| t.get_display_name_or_internal(&s.name))
-                            .unwrap_or_else(|| s.name.clone());
+                        let display = format_skill_display_name(
+                            &s.name,
+                            self.game.data_table.skill_name.as_ref(),
+                        );
                         (display, Some(s.icon_path()))
                     }
                     None => (format!("Skill #{id}"), None),

--- a/client/src/events/skill.rs
+++ b/client/src/events/skill.rs
@@ -4,6 +4,7 @@ use models::enums::EnumWithStringValue;
 use models::enums::action::ActionType;
 use models::enums::effect_id::EffectId;
 use models::enums::skill_enums::SkillEnum;
+use ragnarok_game::data_table::skill_name_table::format_skill_display_name;
 use models::enums::weapon::WeaponType;
 use ragnarok_game::autocounter;
 use ragnarok_game::cast_scope::CastScope;
@@ -104,11 +105,10 @@ impl App {
     }
 
     pub(super) fn skill_display_name(&self, internal_name: &str) -> Option<String> {
-        self.game
-            .data_table
-            .skill_name
-            .as_ref()
-            .map(|table| table.get_display_name_or_internal(internal_name))
+        Some(format_skill_display_name(
+            internal_name,
+            self.game.data_table.skill_name.as_ref(),
+        ))
     }
 
     pub(super) fn skill_display_name_by_id(&self, skill_id: u16) -> Option<String> {

--- a/client/src/overlay/mod.rs
+++ b/client/src/overlay/mod.rs
@@ -1,5 +1,6 @@
 use crate::App;
 use ragnarok_game::cursor::RenderEntry;
+use ragnarok_game::data_table::skill_name_table::format_skill_display_name;
 use ragnarok_game::entity::{Entity, EntityCategory, EntityType};
 use ragnarok_game::sprite_path::JT_HIDDEN_NPC;
 use ragnarok_game::targeting::{GM_TEXT_COLOR, pk_name_color};
@@ -702,13 +703,10 @@ impl App {
 
         let skill_id = pending.skill_id();
         if let Some(internal_name) = self.game.resolve_cast_skill_name(skill_id) {
-            let display_name = self
-                .game
-                .data_table
-                .skill_name
-                .as_ref()
-                .map(|t| t.get_display_name_or_internal(internal_name))
-                .unwrap_or_else(|| internal_name.to_string());
+            let display_name = format_skill_display_name(
+                internal_name,
+                self.game.data_table.skill_name.as_ref(),
+            );
             let level = pending.level();
             let banner_text = if level > 0 {
                 format!("{}(Lv {})", display_name, level)

--- a/lib/game/src/data_table/skill_name_table.rs
+++ b/lib/game/src/data_table/skill_name_table.rs
@@ -9,6 +9,25 @@ pub struct SkillNameTable {
     entries: HashMap<String, String>,
 }
 
+/// Human-facing skill label for every UI surface (skill tree, hotkey tooltip,
+/// cast bubble, companion skill lists, …).
+///
+/// Prefers the GRF `skillnametable` entry. Underscores in either the table
+/// display string or the internal fallback id are turned into spaces so callers
+/// never render raw ids like `MC_MAMMONITE`.
+pub fn format_skill_display_name(
+    internal_name: &str,
+    table: Option<&SkillNameTable>,
+) -> String {
+    table
+        .map(|t| t.get_display_name_or_internal(internal_name))
+        .unwrap_or_else(|| normalize_skill_label(internal_name))
+}
+
+fn normalize_skill_label(name: &str) -> String {
+    name.replace('_', " ")
+}
+
 impl SkillNameTable {
     pub fn from_entries(entries: HashMap<String, String>) -> Self {
         Self { entries }
@@ -31,8 +50,8 @@ impl SkillNameTable {
     pub fn get_display_name_or_internal(&self, internal_name: &str) -> String {
         self.entries
             .get(internal_name)
-            .cloned()
-            .unwrap_or_else(|| internal_name.to_string())
+            .map(|s| normalize_skill_label(s))
+            .unwrap_or_else(|| normalize_skill_label(internal_name))
     }
 }
 
@@ -45,6 +64,10 @@ mod tests {
         let mut entries = HashMap::new();
         entries.insert("SM_BASH".to_string(), "Bash".to_string());
         entries.insert("AL_HEAL".to_string(), "Heal".to_string());
+        entries.insert(
+            "AC_CONCENTRATION".to_string(),
+            "Improve_Concentration".to_string(),
+        );
         let table = SkillNameTable::from_entries(entries);
 
         assert_eq!(table.get_display_name("SM_BASH"), Some("Bash"));
@@ -54,8 +77,32 @@ mod tests {
         );
         assert_eq!(
             table.get_display_name_or_internal("UNKNOWN_SKILL"),
-            "UNKNOWN_SKILL".to_string()
+            "UNKNOWN SKILL".to_string()
+        );
+        assert_eq!(
+            table.get_display_name_or_internal("AC_CONCENTRATION"),
+            "Improve Concentration".to_string()
         );
         assert!(table.get_display_name("MISSING").is_none());
+    }
+
+    #[test]
+    fn format_skill_display_name_shared() {
+        let mut entries = HashMap::new();
+        entries.insert("MC_MAMMONITE".to_string(), "Mammonite".to_string());
+        let table = SkillNameTable::from_entries(entries);
+
+        assert_eq!(
+            format_skill_display_name("MC_MAMMONITE", Some(&table)),
+            "Mammonite"
+        );
+        assert_eq!(
+            format_skill_display_name("MC_MAMMONITE", None),
+            "MC MAMMONITE"
+        );
+        assert_eq!(
+            format_skill_display_name("SM_BASH", Some(&table)),
+            "SM BASH"
+        );
     }
 }

--- a/lib/ui-component/src/game/guild_window.rs
+++ b/lib/ui-component/src/game/guild_window.rs
@@ -7,6 +7,7 @@ use crate::helper::window_chrome::{
 };
 use crate::{BuildCtx, InGameWindow, Window};
 use ragnarok_game::data_table::DataTable;
+use ragnarok_game::data_table::skill_name_table::format_skill_display_name;
 use ragnarok_game::event::GameEvent;
 use ragnarok_game::guild::{GUILD_PERM_EXPEL, GUILD_PERM_INVITE, Guild, GuildPosition};
 use ragnarok_game::job_class::job_class_name;
@@ -1157,11 +1158,7 @@ impl GuildWindow {
             });
 
             let name_color = if dim { OFFLINE_COLOR } else { TEXT };
-            let display = data
-                .skill_name
-                .as_ref()
-                .map(|t| t.get_display_name_or_internal(&s.name))
-                .unwrap_or_else(|| s.name.clone());
+            let display = format_skill_display_name(&s.name, data.skill_name.as_ref());
             ui.text(x + 45.0, row_y + 12.0, &display, name_color);
             ui.text(
                 x + 45.0,

--- a/lib/ui-component/src/game/homun_skill_window.rs
+++ b/lib/ui-component/src/game/homun_skill_window.rs
@@ -7,6 +7,7 @@ use crate::{BuildCtx, InGameWindow, Window};
 use ragnarok_game::companion::HomunculusState;
 use ragnarok_game::data_table::DataTable;
 use ragnarok_game::event::{GameEvent, SkillInfo};
+use ragnarok_game::data_table::skill_name_table::format_skill_display_name;
 use ragnarok_game::skill::SkillTargetType;
 use ragnarok_ui::draw::{self, DrawCall, TextureRef};
 use ragnarok_ui::frame::{ButtonTextures, UiFrame, WidgetId};
@@ -169,7 +170,8 @@ impl HomunSkillWindow {
             });
 
             let name_x = icon_x + ICON_SIZE + 8.0;
-            ui.text(name_x, row_y + 14.0, &skill.name, tc);
+            let display_name = format_skill_display_name(&skill.name, data.skill_name.as_ref());
+            ui.text(name_x, row_y + 14.0, &display_name, tc);
             ui.text(name_x, row_y + 28.0, &format!("Lv : {}", skill.level), tc);
 
             let mut sp_right = x + WIN_W - PAD;
@@ -321,11 +323,7 @@ pub(crate) fn draw_companion_skill_tooltip(
     anchor_x: f32,
     anchor_y: f32,
 ) {
-    let display_name = data
-        .skill_name
-        .as_ref()
-        .map(|t| t.get_display_name_or_internal(&skill.name))
-        .unwrap_or_else(|| skill.name.clone());
+    let display_name = format_skill_display_name(&skill.name, data.skill_name.as_ref());
     let mut lines = vec![display_name];
 
     let type_str = match skill.skill_target_type {

--- a/lib/ui-component/src/game/hotkey_bar.rs
+++ b/lib/ui-component/src/game/hotkey_bar.rs
@@ -6,6 +6,7 @@ use crate::game::equipment_window::EQ_WINDOW_ID;
 use crate::helper::window_chrome::{draw_sys_button, text_color};
 use crate::{BuildCtx, InGameWindow, Window};
 use ragnarok_game::character::Character;
+use ragnarok_game::data_table::skill_name_table::format_skill_display_name;
 use ragnarok_game::display_name::format_equipment_display_name;
 use ragnarok_game::event::{GameEvent, SkillInfo};
 use ragnarok_game::hotkey::{HOTKEY_COLS, HOTKEY_ROWS, HotkeySlotContent};
@@ -516,14 +517,20 @@ impl InGameWindow for HotkeyBarWindow {
                         HotkeySlotContent::Skill { skill_id, level } => character
                             .skills
                             .get_skill(skill_id)
-                            .map(|s| s.name.clone())
+                            .map(|s| s.name.as_str())
                             .or_else(|| {
                                 self.companion_skills
                                     .iter()
                                     .find(|s| s.id == skill_id)
-                                    .map(|s| s.name.clone())
+                                    .map(|s| s.name.as_str())
                             })
-                            .map(|name| format!("{name} Lv.{level}")),
+                            .map(|name| {
+                                let display = format_skill_display_name(
+                                    name,
+                                    data.skill_name.as_ref(),
+                                );
+                                format!("{display} Lv.{level}")
+                            }),
                         HotkeySlotContent::Item { item_id } => {
                             let slot_count_table = data.item_slot_count.as_ref();
                             let card_name_table = data.card_name.as_ref();

--- a/lib/ui-component/src/game/mercenary_skill_window.rs
+++ b/lib/ui-component/src/game/mercenary_skill_window.rs
@@ -8,6 +8,7 @@ use crate::{BuildCtx, InGameWindow, Window};
 use ragnarok_game::companion::MercenaryState;
 use ragnarok_game::data_table::DataTable;
 use ragnarok_game::event::GameEvent;
+use ragnarok_game::data_table::skill_name_table::format_skill_display_name;
 use ragnarok_ui::draw::{self, DrawCall, TextureRef};
 use ragnarok_ui::frame::{ButtonTextures, UiFrame, WidgetId};
 use ragnarok_ui::rect::Rect;
@@ -168,7 +169,8 @@ impl MercenarySkillWindow {
             });
 
             let name_x = icon_x + ICON_SIZE + 8.0;
-            ui.text(name_x, row_y + 14.0, &skill.name, tc);
+            let display_name = format_skill_display_name(&skill.name, data.skill_name.as_ref());
+            ui.text(name_x, row_y + 14.0, &display_name, tc);
             ui.text(name_x, row_y + 28.0, &format!("Lv : {}", skill.level), tc);
             ui.text_right(
                 x + WIN_W - PAD,

--- a/lib/ui-component/src/game/skill_tree_window.rs
+++ b/lib/ui-component/src/game/skill_tree_window.rs
@@ -10,6 +10,7 @@ use crate::helper::window_chrome::{
     FOOTER_TEX, TITLEBAR_TEX, draw_container, draw_footer, draw_sys_button, draw_titlebar,
     text_color,
 };
+use ragnarok_game::data_table::skill_name_table::format_skill_display_name;
 use crate::{BuildCtx, InGameWindow, Window};
 
 pub const SKILL_WINDOW_ID: WidgetId = WidgetId(1200);
@@ -273,11 +274,10 @@ impl InGameWindow for SkillTreeWindow {
                 texture: TextureRef::Named(icon_path),
             });
 
-            let display_name = data
-                .skill_name
-                .as_ref()
-                .map(|t| t.get_display_name_or_internal(&skill.name))
-                .unwrap_or_else(|| skill.name.clone());
+            let display_name = format_skill_display_name(
+                &skill.name,
+                data.skill_name.as_ref(),
+            );
             let name_x = icon_x + ICON_SIZE + 6.0;
             let name_y = row_y + 14.0;
             ui.text(name_x, name_y, &display_name, tc);


### PR DESCRIPTION
## Summary
Skill UIs sometimes showed internal skill ids with underscores (e.g. `MC_MAMMONITE`) instead of the human-readable name from `skillnametable` (e.g. `Mammonite`).

## Changes
- Add shared `format_skill_display_name` helper in `skill_name_table`
- Use it consistently for:
  - Hotkey bar tooltips
  - Skill tree window
  - Cast / skill banners and chat bubbles
  - Homunculus / mercenary skill lists
  - Guild skill list
  - Auto-spell selection list
- Normalize leftover underscores in table display strings and internal fallbacks to spaces

## Test plan
- [x] Unit tests for `format_skill_display_name` / underscore normalization
- [x] In-game: hover hotkey skill → display name without underscores
- [x] Skill tree list names match hotkey / cast bubble

Fixes #10